### PR TITLE
ci: optimize workflows with faster setup actions and separate CI/CD c…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,11 @@
-name: Build and deploy site to GitHub Pages
+name: CI - Build and test
 on:
-  push:
+  pull_request:
     branches: [ "rewrite/main" ]
-  workflow_dispatch:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4.2.2
@@ -24,7 +23,7 @@ jobs:
           cache: 'npm'
 
       - name: Install Node.js packages
-        run: npm ci # clean install
+        run: npm ci
 
       - name: Build stylesheets using Tailwind CSS
         run: npm run-script tailwindcss -- --minify
@@ -40,25 +39,7 @@ jobs:
           JEKYLL_ENV: production
         run: npm run-script jekyll:build
 
-      - name: Upload artifact
-        id: deployment
-        uses: actions/upload-pages-artifact@v3.0.1
-        with:
-          path: dist/
-
-  deploy:
-    runs-on: ubuntu-latest
-    needs: build
-
-    permissions:
-      pages: write
-      id-token: write
-
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4.0.5
+      - name: Check build artifacts
+        run: |
+          ls -la dist/
+          echo "Build completed successfully!"


### PR DESCRIPTION
* Split deployment.yaml: only deploy on push to rewrite/main
* Add ci.yaml: build validation for pull requests
* Replace asdf with dedicated setup actions for 2-3min speedup
* Use npm ci instead of npm install for faster builds
* Add bundler and npm caching for improved performance