### PR TITLE
Add a redirect that always points to the most recent call

### DIFF
--- a/content/redirects/newest-call.html
+++ b/content/redirects/newest-call.html
@@ -1,0 +1,23 @@
+---
+permalink: /resource-call
+redirect: true
+sitemap: false
+---
+{%- assign calls = site.publications | where_exp: "p", "p.title contains 'Open Call'" | sort: "date" -%}
+{%- assign newest = calls | last -%}
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url={{ newest.url }}">
+    <link rel="canonical" href="{{ newest.url }}">
+    <meta name="robots" content="noindex">
+    <title>Redirecting…</title>
+    <script>location.replace("{{ newest.url }}" + location.hash);</script>
+  </head>
+  <body>
+    <p>Redirecting to the latest open call:
+      <a href="{{ newest.url }}">{{ newest.title }}</a>.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
- navigating to `/resource-call` now always redirects to the most recent call
    - Calls identified by title (contains "Open Call"), sorted by date and newest returned